### PR TITLE
resaltando links

### DIFF
--- a/webApp/faq.html
+++ b/webApp/faq.html
@@ -40,7 +40,7 @@
                         <h3>¿Quién puede revisar los resultados?</h3>
                     </i>
                     <h4>Sólo el TRICEL, al igual que en una votación regular.<br>
-                    La urna virtual es pública, pero los votos son ilegibles sin la clave. De todas formas puedes bajar todos los votos cuando quieras, para corroborar, auditar o recontar los votos luego por tu cuenta <a href="./urna_publica.php">aquí</a>.
+                    La urna virtual es pública, pero los votos son ilegibles sin la clave. De todas formas puedes bajar todos los votos cuando quieras, para corroborar, auditar o recontar los votos luego por tu cuenta <a href="./urna_publica.php"><em> <strong>aquí </strong> </em></a>.
                     <br> Por seguridad, estos sólo se actualizan cada 15 minutos, de forma que no sea posible rastrear un voto por su hora de emisión. </h4>
                     <br>
                 </div>

--- a/webApp/papeleta.html
+++ b/webApp/papeleta.html
@@ -23,7 +23,7 @@
                         <i class="fas fa-info-circle">
                             <h3>Completa los campos a continuación y pulsa el botón para generar tu voto virtual.</h3>
                             <h4>Este corresponderá a un archivo .bvf que luego deberás subir a la urna virtual. <br>Puedes informarte más acerca de cómo generamos este archivo y garantizamos tu anonimidad 
-                            <a href="./faq.html">aquí</a> .</h4>
+                            <a href="./faq.html"><em><strong>aquí </strong> </em></a> .</h4>
                         </i>
                     </div>
                     <h2>¿Acepta a la lista "Triple Omega" como Mesa Ejecutiva del CEE-ELO para el periodo 2021?</h2>

--- a/webApp/urna_publica.php
+++ b/webApp/urna_publica.php
@@ -22,7 +22,7 @@
                         <i class="fas fa-info-circle">
                             <h3>Acá puedes consultar todos los votos que han sido emitidos, con un delay de 15 minutos (por anonimidad).</h3>
                             <h4>Los votos son renombrados a su suma de chequeo SHA256, y recomendamos usarla si quieres verificar que tu voto está subido.<br> Más información sobre esto y sobre cómo garantizamos tu anonimidad en 
-                                <a href="./faq.html">aquí</a>
+                                <a href="./faq.html"><em><strong>aquí </strong> </em></a>
                             </h4>
                         </i>
                     </div>


### PR DESCRIPTION
Se resaltan los link con negritas y cursivas.
para diferenciarlo del texto de la pagina.